### PR TITLE
configure.ac: add --with-tirpc option support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,10 +56,23 @@ PKG_CHECK_MODULES(LIBNL3, [libnl-genl-3.0 >= 3.1],,
 AC_SUBST(LIBNL3_CFLAGS)
 AC_SUBST(LIBNL3_LIBS)
 
-PKG_CHECK_MODULES([TIRPC], [libtirpc],,
-                  [AC_MSG_ERROR([tirpc library is required to build nbd-runner])])
-AC_SUBST(TIRPC_CFLAGS)
-AC_SUBST(TIRPC_LIBS)
+AC_ARG_WITH([tirpc],
+    [AS_HELP_STRING([--with-tirpc],
+    [do use tirpc])], [], 
+    [with_tirpc=check])
+if test "x$with_tirpc" == "xyes"; then
+    PKG_CHECK_MODULES(TIRPC, [libtirpc >= 1.1.4],
+        [HAVE_TIRPC=1 AC_DEFINE(HAVE_TIRPC, 1, [Define to 1 if we have tirpc support])],
+     
+        [AC_MSG_ERROR([--with-tirpc given but cannot find libtirpc])
+        HAVE_TIRPC=0 AC_DEFINE(HAVE_TIRPC, 0)])   
+
+    AC_SUBST(TIRPC_CFLAGS)
+    AC_SUBST(TIRPC_LIBS)
+else
+    HAVE_TIRPC=0
+    AC_DEFINE(HAVE_TIRPC, 0, [Define to 1 if we have tirpc support])
+fi
 
 # Checks for libraries.
 # glusterfs-api versions have a prefix of "7."

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -3,13 +3,13 @@ sbin_PROGRAMS = nbd-runner
 nbd_runner_SOURCES = nbd-runner.c nbd-svc-routines.c
 
 nbd_runner_CFLAGS = $(GFAPI_CFLAGS) $(EVENT_CFLAGS) $(GLIB2_CFLAGS) 	\
-		    $(TIRPC_CFLAGS) -DDATADIR=\"$(localstatedir)\"      \
+		    		$(TIRPC_CFLAGS) -DDATADIR=\"$(localstatedir)\"      \
                     -I$(top_builddir)/ -I$(top_srcdir)/utils/           \
                     -I$(top_srcdir)/rpc
 
 nbd_runner_LDADD = $(PTHREAD) $(GFAPI_LIBS) $(EVENT_LIBS) $(GLIB2_LIBS) \
-		   $(TIRPC_LIBS) $(top_builddir)/rpc/libgbrpcxdr.la     \
-		   $(top_builddir)/utils/libutils.la 
+		   		   $(TIRPC_LIBS) $(top_builddir)/rpc/libgbrpcxdr.la     \
+		           $(top_builddir)/utils/libutils.la 
 
 DISTCLEANFILES = Makefile.in
 

--- a/daemon/nbd-runner.c
+++ b/daemon/nbd-runner.c
@@ -157,6 +157,13 @@ static void *nbd_rpc_svc_thread_start(void *arg)
         goto out;
     }
 
+#if HAVE_TIRPC
+    if (listen(listenfd, 16) < 0) {
+        nbd_err("failed to start listening on a socket: %s\n", strerror(errno));
+        goto out;
+    }
+#endif
+
     transp = svctcp_create(listenfd, 0, 0);
     if (!transp) {
         nbd_err("svctcp_create failed, %s\n", strerror(errno));

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -4,9 +4,9 @@ libutils_la_SOURCES = utils.c
 
 noinst_HEADERS = utils.h nbd-log.h
 
-libgb_la_CFLAGS = $(TIPRC_CFLAGS) -DDATADIR=\"$(localstatedir)\"    	   \
-		  -DCONFDIR=\"$(NBD_RUNNER_WORKDIR)\"	   		   \
-		  -I$(top_builddir)/ -I$(top_builddir)/rpc
+libutils_la_CFLAGS = $(TIPRC_CFLAGS) -DDATADIR=\"$(localstatedir)\"    \
+		  			 -DCONFDIR=\"$(NBD_RUNNER_WORKDIR)\"	   		   \
+		  			 -I$(top_builddir)/ -I$(top_builddir)/rpc
 
 libutils_ladir = $(includedir)/utils
 


### PR DESCRIPTION
glibc has removed the rpc functions from current releases. Instead of
relying on glibc providing these, the modern libtirpc library should be
used instead. For the old glibc version or some distribute we will
still use the glibc instead.

Signed-off-by: Xiubo Li <xiubli@redhat.com>