### PR TITLE
runner: split gluster cli as one separate storage handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ stamp-h1
 .deps
 *.spec
 *.tar.gz
+*.swp
 VERSION
 
 cli/nbd-cli

--- a/README.md
+++ b/README.md
@@ -67,39 +67,24 @@ Commands:
 
 # nbd-cli help
 Usage:
-	nbd <command> [<args>]
+ gluster help		-display help for gluster commands
+ ceph help		-display help for ceph commands, TODO
+ global help		-display help for global commands, TODO
+ version		-display the version of nbd-cli
 
-Commands:
-	help
-		display help for nbd commands
+# nbd-cli gluster help
+Usage: 
 
-	create <volname@host:/path> [prealloc] <size SIZE> <host HOST>
-		create path file on the volname volume, prealloc is false as default,
-		and the SIZE is valid with B, K(iB), M(iB), G(iB), T(iB), P(iB), E(iB), Z(iB), Y(iB)
-
-	delete <volname@host:/path> <host HOST>
+	gluster help
+		display help for gluster commands
+	gluster create <volname@host:/path> [prealloc] <size SIZE> <host HOST>
+		create path file on the volname volume, prealloc is false as default, and the SIZE is valid with B, K(iB), M(iB), G(iB), T(iB), P(iB), E(iB), Z(iB), Y(iB)
+	gluster delete <volname@host:/path> <host HOST>
 		delete path file on the volname volume
-
-	map <volname@host:/path> [nbd-device] [threads NUM] [timeout TIME] <host HOST> [readonly]
-		map path file to the nbd device, as default the threads 4, timeout 0, none readonly
-
-	umap <nbd-device>
-		umap the nbd device
-
-	list <map|umap|all>
-		list the mapped|umapped|all nbd devices, all as default
-
-	version
-		show version info and exit.
-
-	<host HOST> means the RPC server IP.
+	gluster map <volname@host:/path> [nbd-device] [timeout TIME] <host HOST> [readonly]
+		map path file to the nbd device, as default the timeout 0, none readonly
+	gluster unmap <nbd-device>
+		unmap the nbd device
+	gluster list <map|unmap|all>
+		list the mapped|unmapped|all nbd devices, all as default
 ```
-
-# TODO:
-
-1. add systemd service support
-2. split the gluster code as one separate handler
-3. add logger file support
-4. add sysconfig file support
-5. add 'nbd-cli list <map|umap|create|all>'
-6. ...

--- a/cli/Makefile.am
+++ b/cli/Makefile.am
@@ -1,14 +1,14 @@
 sbin_PROGRAMS = nbd-cli
 
-nbd_cli_SOURCES = nbd-cli.c
+nbd_cli_SOURCES = nbd-cli.c nbd-cli-cmd.c nbd-cli-gluster.c
 
 nbd_cli_CFLAGS = $(KMOD_CFLAGS) $(LIBNL3_CFLAGS) $(TIRPC_CFLAGS)        \
-                 -DDATADIR=\"$(localstatedir)\"                         \
+                 $(GLIB2_CFLAGS) -DDATADIR=\"$(localstatedir)\"         \
                  -I$(top_builddir)/ -I$(top_srcdir)/utils/              \
                  -I$(top_srcdir)/rpc
 
-nbd_cli_LDADD = $(KMOD_LIBS) $(LIBNL3_LIBS) $(TIRPC_LIBS) 		\
-                $(top_builddir)/rpc/libnbdrpcxdr.la 			\
+nbd_cli_LDADD = $(KMOD_LIBS) $(LIBNL3_LIBS) $(TIRPC_LIBS) 	            \
+                $(GLIB2_LIBS) $(top_builddir)/rpc/libnbdrpcxdr.la       \
                 $(top_builddir)/utils/libutils.la 
 
 DISTCLEANFILES = Makefile.in

--- a/cli/nbd-cli-cmd.c
+++ b/cli/nbd-cli-cmd.c
@@ -1,0 +1,857 @@
+/*
+  Copyright (c) 2019 Red Hat, Inc. <http://www.redhat.com>
+  This file is part of nbd-runner.
+
+  This file is licensed to you under your choice of the GNU Lesser
+  General Public License, version 3 or any later version (LGPLv3 or
+  later), or the GNU General Public License, version 2 (GPLv2), in all
+  cases as published by the Free Software Foundation.
+*/
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <errno.h>
+#include <linux/nbd.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netlink/netlink.h>
+#include <libnl3/netlink/genl/genl.h>
+#include <libnl3/netlink/genl/mngt.h>
+#include <libnl3/netlink/genl/ctrl.h>
+
+#include "rpc_nbd.h"
+#include "utils/utils.h"
+#include "nbd-log.h"
+#include "nbd-netlink.h"
+#include "nbd-cli-cmd.h"
+
+struct timeval TIMEOUT = {.tv_sec = 15};
+
+static struct addrinfo *nbd_get_sock_addr(const char *host)
+{
+  int ret;
+  struct addrinfo hints, *res;
+  char port[32];
+
+  memset(&hints, 0, sizeof hints);
+  hints.ai_family = AF_INET;
+  hints.ai_socktype = SOCK_STREAM;
+
+  snprintf(port, 32, "%d", NBD_RPC_SVC_PORT);
+
+  ret = getaddrinfo(host, port, &hints, &res);
+  if (ret) {
+    nbd_err("getaddrinfo(%s) failed (%s)", host, gai_strerror(ret));
+    return NULL;
+  }
+
+  return res;
+}
+
+int nbd_create_backstore(int count, char **options, int type)
+{
+    CLIENT *clnt = NULL;
+    struct nbd_create *create;
+    struct nbd_response rep = {0,};
+    struct addrinfo *res;
+    char *host = NULL;
+    int sock = RPC_ANYSOCK;
+    int ret = 0;
+    int ind;
+    int len;
+    int max_len = 1024;
+
+    create = calloc(1, sizeof(struct nbd_create));
+    if (!create) {
+        nbd_err("No memory for nbd_create!\n");
+        return -ENOMEM;
+    }
+
+    create->type = type;
+
+    len = snprintf(create->cfgstring, max_len, "key=%s", options[0]);
+    if (len < 0) {
+        nbd_err("snprintf error for volinfo, %s!\n", strerror(errno));
+        ret = -errno;
+        goto err;
+    }
+    create->cfgstring[len++] = ';';
+
+    ind = 1;
+    while (ind < count) {
+        if (!strcmp("host", options[ind])) {
+            if (ind + 1 >= count) {
+                nbd_err("Invalid argument 'host <HOST>'!\n\n");
+                goto err;
+            }
+
+            host = strdup(options[ind + 1]);
+            if (!host) {
+                nbd_err("No memory for host!\n");
+                goto err;
+            }
+
+            ind += 2;
+        } else if (!strcmp("prealloc", options[ind])) {
+            create->prealloc = true;
+            ind += 1;
+        } else if (!strcmp("size", options[ind])) {
+            if (ind + 1 >= count) {
+                nbd_err("Invalid argument 'size <SIZE>'!\n\n");
+                goto err;
+            }
+
+            if (!nbd_valid_size(options[ind + 1])) {
+                nbd_err("Invalid size!\n");
+                ret = -EINVAL;
+                goto err;
+            }
+
+            create->size = nbd_parse_size(options[ind + 1], 0);
+            if (create->size < 0) {
+                nbd_err("Invalid size value: %s!\n", options[ind + 1]);
+                ret = -EINVAL;
+                goto err;
+            }
+
+            ind += 2;
+        } else {
+            nbd_err("Invalid option : %s\n", options[ind]);
+            ret = -EINVAL;
+            goto err;
+        }
+    }
+
+    if (!host) {
+        nbd_err("<host HOST> param is a must here!\n");
+        goto err;
+    }
+
+    res = nbd_get_sock_addr(host);
+    if (!res) {
+        nbd_err("failed to get sock addr!\n");
+        goto err;
+    }
+
+    clnt = clnttcp_create((struct sockaddr_in *)res->ai_addr, RPC_NBD,
+                          RPC_NBD_VERS, &sock, 0, 0);
+    if (!clnt) {
+        nbd_err("clnttcp_create failed, %s!\n", strerror(errno));
+        goto err;
+    }
+
+    if (nbd_create_1(create, &rep, clnt) != RPC_SUCCESS) {
+        nbd_err("nbd_create_1 failed!\n");
+        goto err;
+    }
+
+    ret = rep.exit;
+    if (ret && rep.out)
+        nbd_err("Create failed: %s\n", rep.out);
+    else
+        nbd_out("Create succeeded!\n");
+
+err:
+    if (clnt) {
+        if (rep.out && !clnt_freeres(clnt, (xdrproc_t)xdr_nbd_response,
+                                     (char *)&rep))
+            nbd_err("clnt_freeres failed!\n");
+        clnt_destroy(clnt);
+    }
+
+    free(host);
+    free(create);
+    return ret;
+}
+
+int nbd_delete_backstore(int count, char **options, int type)
+{
+    CLIENT *clnt = NULL;
+    struct nbd_delete *delete;
+    struct nbd_response rep = {0,};
+    struct addrinfo *res;
+    char *host = NULL;
+    int sock = RPC_ANYSOCK;
+    int ret = 0;
+    int len;
+    int max_len = 1024;
+
+    delete = calloc(1, sizeof(struct nbd_delete));
+    if (!delete) {
+        nbd_err("No memory for nbd_delete!\n");
+        return -ENOMEM;
+    }
+
+    delete->type = type;
+
+    len = snprintf(delete->cfgstring, max_len, "key=%s", options[0]);
+    if (len < 0) {
+        ret = -errno;
+        nbd_err("snprintf error for volinfo, %s!\n", strerror(errno));
+        goto err;
+    }
+
+    if (!strcmp("host", options[1])) {
+        if (count < 3) {
+            nbd_err("Invalid argument 'host <HOST>'!\n\n");
+            goto err;
+        }
+
+        host = strdup(options[2]);
+        if (!host) {
+            ret = -ENOMEM;
+            nbd_err("No memory for host!\n");
+            goto err;
+        }
+    }
+
+    if (!host) {
+        nbd_err("<host HOST> param is a must here!\n");
+        goto err;
+    }
+
+    res = nbd_get_sock_addr(host);
+    if (!res) {
+        ret = -ENOMEM;
+        nbd_err("failed to get sock addr!\n");
+        goto err;
+    }
+
+    clnt = clnttcp_create((struct sockaddr_in *)res->ai_addr, RPC_NBD,
+                          RPC_NBD_VERS, &sock, 0, 0);
+    if (!clnt) {
+        ret = -errno;
+        nbd_err("clnttcp_create failed, %s!\n", strerror(errno));
+        goto err;
+    }
+
+    if (nbd_delete_1(delete, &rep, clnt) != RPC_SUCCESS) {
+        ret = -errno;
+        nbd_err("nbd_delete_1 failed!\n");
+        goto err;
+    }
+
+    ret = rep.exit;
+    if (ret && rep.out)
+        nbd_err("Delete failed: %s\n", rep.out);
+    else
+        nbd_out("Delete succeeded!\n");
+
+err:
+    if (clnt) {
+        if (rep.out && !clnt_freeres(clnt, (xdrproc_t)xdr_nbd_response,
+                                     (char *)&rep))
+            nbd_err("clnt_freeres failed!\n");
+        clnt_destroy(clnt);
+    }
+
+    free(host);
+    free(delete);
+    return ret;
+}
+
+typedef enum {
+    NBD_LIST_MAPPED,
+    NBD_LIST_UNMAPPED,
+    NBD_LIST_ALL,
+} list_type;
+
+static int nbd_list_type = NBD_LIST_ALL;
+
+static struct nla_policy nbd_device_policy[NBD_DEVICE_ATTR_MAX + 1] = {
+    [NBD_DEVICE_INDEX]              =       { .type = NLA_U32 },
+    [NBD_DEVICE_CONNECTED]          =       { .type = NLA_U8 },
+};
+
+static int map_nl_callback(struct nl_msg *msg, void *arg)
+{
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    struct nlattr *msg_attr[NBD_ATTR_MAX + 1];
+    uint32_t index;
+    int ret;
+
+    if (nla_parse(msg_attr, NBD_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
+                  genlmsg_attrlen(gnlh, 0), NULL) < 0) {
+        nbd_err("Invalid response from the kernel\n");
+        return NL_STOP;
+    }
+
+    if (!msg_attr[NBD_ATTR_INDEX]) {
+        nbd_err("Did not receive index from the kernel\n");
+        return NL_STOP;
+    }
+
+    index = nla_get_u32(msg_attr[NBD_ATTR_INDEX]);
+    nbd_out("Connected /dev/nbd%d\n", (int)index);
+
+    return NL_OK;
+}
+
+static int list_nl_callback(struct nl_msg *msg, void *arg)
+{
+    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
+    struct nlattr *msg_attr[NBD_ATTR_MAX + 1];
+    uint32_t index;
+    struct nlattr *attr;
+    int rem;
+    int status;
+
+    if (nla_parse(msg_attr, NBD_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
+                  genlmsg_attrlen(gnlh, 0), NULL) < 0) {
+        nbd_err("Invalid response from the kernel\n");
+        return NL_STOP;
+    }
+
+    if (!msg_attr[NBD_ATTR_DEVICE_LIST]) {
+        nbd_err("NBD_ATTR_DEVICE_LIST not set in cmd!\n");
+        return NL_STOP;
+    }
+
+    nla_for_each_nested(attr, msg_attr[NBD_ATTR_DEVICE_LIST], rem) {
+        struct nlattr *devices[NBD_DEVICE_ATTR_MAX + 1];
+
+        if (nla_type(attr) != NBD_DEVICE_ITEM) {
+            nbd_err("NBD_DEVICE_ITEM not set!\n");
+            return NL_STOP;
+        }
+
+        if (nla_parse_nested(devices, NBD_DEVICE_ATTR_MAX, attr,
+                             nbd_device_policy) < 0) {
+            nbd_err("nbd: error processing device list\n");
+            return NL_STOP;
+        }
+
+        index = (int)nla_get_u32(devices[NBD_DEVICE_INDEX]);
+        status = (int)nla_get_u8(devices[NBD_DEVICE_CONNECTED]);
+
+        switch (nbd_list_type) {
+        case NBD_LIST_MAPPED:
+            if (status)
+                nbd_out("/dev/nbd%d \t%s\n", index, "Mapped");
+            break;
+        case NBD_LIST_UNMAPPED:
+            if (!status)
+                nbd_out("/dev/nbd%d \t%s\n", index, "Unmapped");
+            break;
+        case NBD_LIST_ALL:
+            nbd_out("/dev/nbd%d \t%s\n", index,
+                    status ? "Mapped" : "Unmapped");
+            break;
+        default:
+            nbd_err("Invalid list type: %d!\n", nbd_list_type);
+            return NL_STOP;
+        }
+    }
+
+    return NL_OK;
+}
+
+static struct nl_sock *nbd_setup_netlink(int *driver_id, int cmd)
+{
+    int (*nl_callback_fn)(struct nl_msg *, void *);
+    struct nl_sock *netfd;
+
+    if (!driver_id)
+        return NULL;
+
+    netfd = nl_socket_alloc();
+    if (!netfd) {
+        nbd_err("Couldn't alloc socket, %s!\n", strerror(errno));
+        return NULL;
+    }
+
+    switch (cmd) {
+    case NBD_CLI_MAP:
+        nl_callback_fn = map_nl_callback;
+        break;
+    case NBD_CLI_LIST:
+        nl_callback_fn = list_nl_callback;
+        break;
+    case NBD_CLI_UNMAP:
+    default:
+        nl_callback_fn = genl_handle_msg;
+    }
+
+    nl_socket_modify_cb(netfd, NL_CB_VALID, NL_CB_CUSTOM, nl_callback_fn, NULL);
+
+    if (genl_connect(netfd)) {
+        nbd_err("Couldn't connect to the nbd netlink socket, %s!\n",
+                strerror(errno));
+        goto err;
+    }
+
+    *driver_id = genl_ctrl_resolve(netfd, "nbd");
+    if (*driver_id < 0) {
+        nbd_err("Couldn't resolve the nbd netlink family, %s!\n",
+                strerror(errno));
+        goto err;
+    }
+
+    return netfd;
+err:
+    nl_socket_free(netfd);
+    return NULL;
+}
+
+static int nbd_device_connect(char *cfg, struct nl_sock *netfd, int sockfd,
+                              int driver_id, ssize_t size, ssize_t blk_size,
+                              int timeout, int dev_index, bool readonly)
+{
+    struct nlattr *sock_attr;
+    struct nlattr *sock_opt;
+    struct nl_msg *msg;
+    int flags = readonly ? NBD_FLAG_READ_ONLY : 0;
+    struct nego_request nhdr;
+    struct nego_reply nrep;
+    char *buf;
+
+    nhdr.len = strlen(cfg);
+    nbd_socket_write(sockfd, &nhdr, sizeof(struct nego_request));
+    nbd_socket_write(sockfd, cfg, nhdr.len);
+
+    nbd_socket_read(sockfd, &nrep, sizeof(struct nego_reply));
+    if (nrep.exit) {
+        if (nrep.len) {
+            buf = malloc(nrep.len + 1);
+            nbd_socket_read(sockfd, &buf, nrep.len);
+            nbd_err("nego failed: %s, %d\n", buf, nrep.exit);
+            free(buf);
+        } else {
+            nbd_err("nego failed: %d\n", buf, nrep.exit);
+        }
+        goto nla_put_failure;
+    }
+
+    msg = nlmsg_alloc();
+    if (!msg) {
+        nbd_err("Couldn't allocate netlink message, %s!\n",
+                strerror(errno));
+        goto nla_put_failure;
+    }
+
+    genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0,
+            NBD_CMD_CONNECT, 0);
+
+    /* -1 means alloc the device dynamically */
+    if (dev_index < -1)
+        dev_index = -1;
+    NLA_PUT_U32(msg, NBD_ATTR_INDEX, dev_index);
+    NLA_PUT_U64(msg, NBD_ATTR_SIZE_BYTES, size);
+    NLA_PUT_U64(msg, NBD_ATTR_BLOCK_SIZE_BYTES,
+                blk_size ? blk_size : NBD_DEFAULT_SECTOR_SIZE);
+    NLA_PUT_U64(msg, NBD_ATTR_SERVER_FLAGS, flags);
+    if (timeout)
+        NLA_PUT_U64(msg, NBD_ATTR_TIMEOUT, timeout);
+
+    sock_attr = nla_nest_start(msg, NBD_ATTR_SOCKETS);
+    if (!sock_attr) {
+        nbd_err("Couldn't nest the socket!\n");
+        goto nla_put_failure;
+    }
+    sock_opt = nla_nest_start(msg, NBD_SOCK_ITEM);
+    if (!sock_opt) {
+        nbd_err("Couldn't nest the socket item!\n");
+        goto nla_put_failure;
+    }
+
+    NLA_PUT_U32(msg, NBD_SOCK_FD, sockfd);
+    nla_nest_end(msg, sock_opt);
+    nla_nest_end(msg, sock_attr);
+
+    if (nl_send_sync(netfd, msg) < 0) {
+        nbd_err("Failed to setup device, check dmesg!\n");
+        goto nla_put_failure;
+    }
+
+    return 0;
+
+nla_put_failure:
+    return -1;
+}
+
+static int nbd_connect_to_server(char *host, int port)
+{
+    struct sockaddr_in addr;
+    int sock;
+    int ret;
+
+    if (!host || port < 0) {
+        nbd_err("Invalid host or port param!\n");
+        return -1;
+    }
+
+    sock = socket(AF_INET, SOCK_STREAM, 0);
+    if(sock < 0){
+        nbd_err("failed to create socket: %s\n", strerror(errno));
+        return -1;
+    }
+
+    bzero(&addr, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr(host);
+    addr.sin_port = htons(port);
+
+    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        nbd_err("connect error: %s\n", strerror(errno));
+        goto err;
+    }
+
+    return sock;
+
+err:
+    close(sock);
+    return -1;
+}
+
+static int _nbd_map_device(char *cfg, struct nbd_response *rep, int dev_index,
+                           int timeout, bool readonly)
+{
+    int ret;
+    int sockfd;
+    struct nl_sock *netfd;
+    int driver_id;
+
+    /* Connect to server for IOs */
+    sockfd = nbd_connect_to_server(rep->host, atoi(rep->port));
+    if (sockfd < 0)
+        return -1;
+
+    /* Setup netlink to configure the nbd device */
+    netfd = nbd_setup_netlink(&driver_id, NBD_CLI_MAP);
+    if (!netfd)
+        return -1;
+
+    /* Setup the IOs sock fd to nbd device to start IOs */
+    ret = nbd_device_connect(cfg, netfd, sockfd, driver_id, rep->size,
+                             rep->blksize, timeout, dev_index, readonly);
+
+    if (!ret)
+        return 0;
+
+err:
+    close(sockfd);
+    nl_socket_free(netfd);
+    return -1;
+}
+
+int nbd_map_device(int count, char **options, int type)
+{
+    CLIENT *clnt = NULL;
+    struct nbd_map *map;
+    struct nbd_response rep = {0,};
+    struct addrinfo *res;
+    char *host = NULL;
+    int sock = RPC_ANYSOCK;
+    int dev_index = -1;
+    int timeout = 0;
+    bool readonly = false;
+    int ret = 0;
+    int len;
+    int ind;
+    int max_len = 1024;
+
+    map = calloc(1, sizeof(struct nbd_map));
+    if (!map) {
+        nbd_err("No memory for nbd_map!\n");
+        return -ENOMEM;
+    }
+
+    map->type = type;
+
+    len = snprintf(map->cfgstring, max_len, "key=%s", options[0]);
+    if (len < 0) {
+        ret = -errno;
+        nbd_err("snprintf error for volinfo, %s!\n", strerror(errno));
+        goto err;
+    }
+
+    map->cfgstring[len++] = ';';
+
+    ind = 1;
+    while (ind < count) {
+        if (!strncmp("/dev/nbd", options[ind], strlen("/dev/nbd"))) {
+            if (sscanf(options[ind], "/dev/nbd%d", &dev_index) != 1) {
+                ret = -errno;
+                nbd_err("Invalid nbd-device!\n");
+                goto err;
+            }
+
+            ind += 1;
+        } else if (!strcmp("host", options[ind])) {
+            if (ind + 1 >= count) {
+                nbd_err("Invalid argument 'host <HOST>'!\n\n");
+                goto err;
+            }
+
+            host = strdup(options[ind + 1]);
+            if (!host) {
+                ret = -ENOMEM;
+                nbd_err("No memory for host!\n");
+                goto err;
+            }
+
+            ind += 2;
+        } else if (!strcmp("readonly", options[ind])) {
+            map->readonly = true;
+            ind += 1;
+        } else if (!strcmp("timeout", options[ind])) {
+            if (ind + 1 >= count) {
+                nbd_err("Invalid argument 'timeout <TIME>'!\n\n");
+                goto err;
+            }
+
+            timeout = atoi(options[ind + 1]);
+            if (timeout < 0) {
+                ret = -EINVAL;
+                nbd_err("Invalid timeout value!\n");
+                goto err;
+            }
+
+            ind += 2;
+        } else {
+            ret = -EINVAL;
+            nbd_err("Invalid argument '%s'!\n", options[ind]);
+            goto err;
+        }
+    }
+
+    if (!host) {
+        nbd_err("<host HOST> param is a must here!\n");
+        goto err;
+    }
+
+    res = nbd_get_sock_addr(host);
+    if (!res) {
+        ret = -ENOMEM;
+        nbd_err("failed to get sock addr!\n");
+        goto err;
+    }
+
+    clnt = clnttcp_create((struct sockaddr_in *)res->ai_addr, RPC_NBD,
+                          RPC_NBD_VERS, &sock, 0, 0);
+    if (!clnt) {
+        ret = -errno;
+        nbd_err("clnttcp_create failed, %s!\n", strerror(errno));
+        goto err;
+    }
+
+    if (nbd_map_1(map, &rep, clnt) != RPC_SUCCESS) {
+        ret = -errno;
+        nbd_err("nbd_map_1 failed!\n");
+        goto err;
+    }
+
+    ret = rep.exit;
+    if (ret && rep.out) {
+        nbd_err("Map failed: %s\n", rep.out);
+        goto err;
+    }
+
+    /* create the /dev/nbdX device */
+    ret = _nbd_map_device(map->cfgstring, &rep, dev_index, timeout, readonly);
+    if (ret < 0) {
+        nbd_err("failed to init the /dev/nbd device!\n");
+        goto err;
+    }
+
+    nbd_out("Map succeeded!\n");
+
+err:
+    if (clnt) {
+        if (rep.out && !clnt_freeres(clnt, (xdrproc_t)xdr_nbd_response,
+                                     (char *)&rep))
+            nbd_err("clnt_freeres failed!\n");
+        clnt_destroy(clnt);
+    }
+
+    free(host);
+    free(map);
+    return ret;
+}
+
+static int unmap_device(struct nl_sock *netfd, int driver_id, int index)
+{
+    struct nl_msg *msg;
+    int ret = 0;
+
+    msg = nlmsg_alloc();
+    if (!msg) {
+        nbd_err("Couldn't allocate netlink message!\n");
+        ret = -1;
+        goto nla_put_failure;
+    }
+
+    genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0,
+            NBD_CMD_DISCONNECT, 0);
+    NLA_PUT_U32(msg, NBD_ATTR_INDEX, index);
+    if (nl_send_sync(netfd, msg) < 0) {
+        nbd_err("Failed to disconnect device, check dmsg\n");
+        ret = -1;
+    }
+
+    nbd_out("Unmap succeeded!\n");
+
+nla_put_failure:
+    return ret;
+}
+
+int nbd_unmap_device(int count, char **options, int type)
+{
+    struct nl_sock *netfd;
+    int driver_id;
+    int index = -1;
+
+    if (sscanf(options[0], "/dev/nbd%d", &index) != 1) {
+        nbd_err("Invalid nbd device target!\n");
+        return -1;
+    }
+
+    if (index < 0) {
+        nbd_err("Invalid nbd device target!\n");
+        return -1;
+    }
+
+    netfd = nbd_setup_netlink(&driver_id, NBD_CLI_UNMAP);
+    if (!netfd)
+        return -1;
+
+    return unmap_device(netfd, driver_id, index);
+}
+
+int nbd_list_devices(int count, char **options, int type)
+{
+    struct nl_sock *netfd;
+    struct nl_msg *msg;
+    int driver_id;
+
+    if (!strcmp(options[0], "map")) {
+        nbd_list_type = NBD_LIST_MAPPED;
+    } else if (!strcmp(options[0], "unmap")) {
+        nbd_list_type = NBD_LIST_UNMAPPED;
+    } else if (!strcmp(options[0], "all")) {
+        nbd_list_type = NBD_LIST_ALL;
+    } else {
+        nbd_err("Invalid argument for list!\n");
+        return -1;
+    }
+
+    netfd = nbd_setup_netlink(&driver_id, NBD_CLI_LIST);
+    if (!netfd)
+        return -1;
+
+    msg = nlmsg_alloc();
+    if (!msg) {
+        nbd_err("Couldn't allocate netlink message, %s!\n",
+                strerror(errno));
+        goto nla_put_failure;
+    }
+
+    genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0,
+            NBD_CMD_STATUS, 0);
+    /*
+     * -1 means list all the devices mapped and
+     *  unmapped in kernel space
+     */
+    NLA_PUT_U32(msg, NBD_ATTR_INDEX, -1);
+
+    if (nl_send_sync(netfd, msg) < 0)
+        nbd_err("Failed to setup device, check dmesg\n");
+
+    return 0;
+
+nla_put_failure:
+    nl_socket_free(netfd);
+    return -1;
+}
+
+int nbd_register_cmds(GHashTable *cmds_hash, struct cli_cmd *cmds)
+{
+    char *key;
+    char *sep, *q, *tmp;
+    const char *p;
+    int len;
+    int i;
+
+    if (!cmds)
+        return -1;
+
+    for (i = 0; cmds[i].pattern; i++) {
+        key = calloc(1, 1024);
+        if (!key) {
+            nbd_err("No memory for cmds_hash key!\n");
+            return -1;
+        }
+
+        /* Skip the white spaces fist */
+        p = cmds[i].pattern;
+        while (*p == ' ')
+            p++;
+
+        /* Parse the backstore type, like "gluster" and "ceph" */
+        sep = strchr(p, ' ');
+        if (!sep) {
+            strcpy(key, p);
+            goto insert;
+        }
+        len = sep - p;
+        strncpy(key, p, len);
+        p += len;
+
+        /* The hash key will be like "backstore_type cmd" */
+        key[len++] = ' ';
+        q = key + len;
+
+        while (*p == ' ')
+            p++;
+
+        /* Parse the cmd, like "create", "delete", "map" */
+        sep = strchr(p, ' ');
+        if (!sep) {
+            strcpy(q, p);
+        } else {
+            len = sep - p;
+            strncpy(q, p, len);
+            q[len] = '\0';
+        }
+insert:
+        g_hash_table_insert(cmds_hash, key, &cmds[i]);
+    }
+
+    return 0;
+}
+
+static void free_key(gpointer key)
+{
+    free(key);
+}
+
+GHashTable *nbd_register_backstores(void)
+{
+    GHashTable *cmds_hash;
+
+    cmds_hash = g_hash_table_new_full(g_str_hash, g_str_equal, free_key, NULL);
+    if (!cmds_hash) {
+        nbd_err("failed to create cmds_hash table!\n");
+        return NULL;
+    }
+
+    if (cli_cmd_gluster_register(cmds_hash)) {
+        nbd_err("failed to register gluster cmds!\n");
+        goto err;
+    }
+
+    return cmds_hash;
+
+err:
+    g_hash_table_destroy(cmds_hash);
+    return NULL;
+}
+
+void nbd_unregister_backstores(GHashTable *cmds_hash)
+{
+    if (cmds_hash)
+        g_hash_table_destroy(cmds_hash);
+}

--- a/cli/nbd-cli-cmd.h
+++ b/cli/nbd-cli-cmd.h
@@ -1,0 +1,51 @@
+/*
+   Copyright (c) 2019 Red Hat, Inc. <http://www.redhat.com>
+   This file is part of nbd-runner.
+
+   This file is licensed to you under your choice of the GNU Lesser
+   General Public License, version 3 or any later version (LGPLv3 or
+   later), or the GNU General Public License, version 2 (GPLv2), in all
+   cases as published by the Free Software Foundation.
+*/
+#ifndef __NBD_CLI_CMD_H__
+#define __NBD_CLI_CMD_H__
+
+#include <glib.h>
+#include <gmodule.h>
+
+enum {
+    NBD_CLI_HELP,
+    NBD_CLI_CREATE,
+    NBD_CLI_DELETE,
+    NBD_CLI_MAP,
+    NBD_CLI_UNMAP,
+    NBD_CLI_LIST,
+
+    NBD_CLI_MAX
+};
+
+typedef int (*cli_cmd_call_t)(int, char **);
+
+struct cli_cmd {
+    const char *pattern;
+    cli_cmd_call_t call;
+    const char *desc;
+    bool disable;
+};
+
+/* Register the cli cmds */
+int nbd_register_cmds(GHashTable *cmds_hash, struct cli_cmd *cmds);
+
+/* Register/unregister all the backstores */
+GHashTable *nbd_register_backstores(void);
+void nbd_unregister_backstores(GHashTable *cmds_hash);
+
+/* This is used to register the gluster backstore */
+int cli_cmd_gluster_register(GHashTable *cmds_hash);
+
+int nbd_create_backstore(int count, char **options, int type);
+int nbd_delete_backstore(int count, char **options, int type);
+int nbd_map_device(int count, char **options, int type);
+int nbd_unmap_device(int count, char **options, int type);
+int nbd_list_devices(int count, char **options, int type);
+#endif /* __CLI_CMD_H__ */

--- a/cli/nbd-cli-gluster.c
+++ b/cli/nbd-cli-gluster.c
@@ -1,0 +1,104 @@
+/*
+  Copyright (c) 2019 Red Hat, Inc. <http://www.redhat.com>
+  This file is part of nbd-runner.
+
+  This file is licensed to you under your choice of the GNU Lesser
+  General Public License, version 3 or any later version (LGPLv3 or
+  later), or the GNU General Public License, version 2 (GPLv2), in all
+  cases as published by the Free Software Foundation.
+*/
+
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "rpc_nbd.h"
+#include "utils/utils.h"
+#include "nbd-log.h"
+#include "nbd-cli-cmd.h"
+
+struct cli_cmd gluster_cmds[];
+
+static int gluster_help_routine(int count, char **options)
+{
+    int i;
+
+    _nbd_out("Usage: \n\n");
+    for (i = 0; gluster_cmds[i].pattern; i++) {
+        if (gluster_cmds[i].disable)
+            continue;
+
+        _nbd_out("\t%s\n", gluster_cmds[i].pattern);
+        _nbd_out("\t\t%s\n", gluster_cmds[i].desc);
+    }
+    _nbd_out("\n");
+}
+
+static int gluster_create_routine(int count, char **options)
+{
+    return nbd_create_backstore(count, options, NBD_BACKSTORE_GLUSTER);
+}
+
+static int gluster_delete_routine(int count, char **options)
+{
+    return nbd_delete_backstore(count, options, NBD_BACKSTORE_GLUSTER);
+}
+
+static int gluster_map_routine(int count, char **options)
+{
+    return nbd_map_device(count, options, NBD_BACKSTORE_GLUSTER);
+}
+
+static int gluster_unmap_routine(int count, char **options)
+{
+    return nbd_unmap_device(count, options, NBD_BACKSTORE_GLUSTER);
+}
+
+static int gluster_list_routine(int count, char **options)
+{
+    return nbd_list_devices(count, options, NBD_BACKSTORE_GLUSTER);
+}
+
+
+struct cli_cmd gluster_cmds[] = {
+    {.pattern = "gluster",
+     .call    = gluster_help_routine,
+     .desc    = "display help for gluster commands",
+     .disable = true,
+    },
+    {.pattern = "gluster help",
+     .call    = gluster_help_routine,
+     .desc    = "display help for gluster commands",
+    },
+    {.pattern = "gluster create <volname@host:/path> [prealloc] <size SIZE> <host HOST>",
+     .call    = gluster_create_routine,
+     .desc    = "create path file on the volname volume, prealloc is false as default, and the SIZE is valid with B, K(iB), M(iB), G(iB), T(iB), P(iB), E(iB), Z(iB), Y(iB)",
+    },
+    {.pattern = "gluster delete <volname@host:/path> <host HOST>",
+     .call    = gluster_delete_routine,
+     .desc    = "delete path file on the volname volume",
+    },
+    {.pattern = "gluster map <volname@host:/path> [nbd-device] [timeout TIME] <host HOST> [readonly]",
+     .call    = gluster_map_routine,
+     .desc    = "map path file to the nbd device, as default the timeout 0, none readonly",
+    },
+    {.pattern = "gluster unmap <nbd-device>",
+     .call    = gluster_unmap_routine,
+     .desc    = "unmap the nbd device",
+    },
+    {.pattern = "gluster list <map|unmap|all>",
+     .call    = gluster_list_routine,
+     .desc    = "list the mapped|unmapped|all nbd devices, all as default",
+    },
+    {.pattern = NULL,
+     .call    = NULL,
+     .desc    = NULL,
+    },
+};
+
+int cli_cmd_gluster_register(GHashTable *cmds_hash)
+{
+    return nbd_register_cmds(cmds_hash, gluster_cmds);
+}

--- a/cli/nbd-cli.c
+++ b/cli/nbd-cli.c
@@ -14,94 +14,28 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <pthread.h>
-#include <getopt.h>
-#include <stdlib.h>
-#include <ctype.h>
 #include <errno.h>
-#include <inttypes.h>
-#include <linux/types.h>
-#include <linux/nbd.h>
-#include <fcntl.h>
 #include <libkmod.h>
-#include <sys/utsname.h>
 #include <sys/stat.h>
-#include <netdb.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <netinet/in.h>
-#include <libnl3/netlink/genl/genl.h>
-#include <libnl3/netlink/genl/mngt.h>
-#include <libnl3/netlink/genl/ctrl.h>
-#include <netlink/netlink.h>
-#include <netlink/genl/genl.h>
-#include <netlink/genl/ctrl.h>
-#include <arpa/inet.h>
+#include <sys/utsname.h>
 
 #include "rpc_nbd.h"
 #include "utils/utils.h"
 #include "nbd-log.h"
-#include "nbd-netlink.h"
-
-struct timeval TIMEOUT = {.tv_sec = 15};
+#include "nbd-cli-cmd.h"
 
 static void usage(void)
 {
     _nbd_out("Usage:\n"
-             "\tnbd <backstore_type> <command> [<args>]\n\n"
-             "Backstore types:\n"
-             "\tgluster: for Glusterfs project\n"
-             "\tceph: for Ceph project\n"
-             "\n"
-             "Commands:\n"
-             "\thelp\n"
-             "\t\tdisplay help for nbd commands\n\n"
-             "\tcreate <volname@host:/path> [prealloc] <size SIZE> <host HOST>\n"
-             "\t\tcreate path file on the volname volume, prealloc is false as default,\n"
-             "\t\tand the SIZE is valid with B, K(iB), M(iB), G(iB), T(iB), P(iB), E(iB), Z(iB), Y(iB)\n\n"
-             "\tdelete <volname@host:/path> <host HOST>\n"
-             "\t\tdelete path file on the volname volume\n\n"
-             "\tmap <volname@host:/path> [nbd-device] [threads NUM] [timeout TIME] <host HOST> [readonly]\n"
-             "\t\tmap path file to the nbd device, as default the threads 4, timeout 0, none readonly\n\n"
-             "\tumap <nbd-device>\n"
-             "\t\tumap the nbd device\n\n"
-             "\tlist <map|umap|all>\n"
-             "\t\tlist the mapped|umapped|all nbd devices, all as default\n\n"
-             "\tversion\n"
-             "\t\tshow version info and exit.\n\n"
-             "\t<host HOST> means the RPC server IP.\n"
+            " gluster help\t\t-display help for gluster commands\n"
+            " ceph help\t\t-display help for ceph commands, TODO\n"
+            " global help\t\t-display help for global commands, TODO\n"
+            " version\t\t-display the version of nbd-cli\n\n"
             );
-}
-
-static const char *const nbd_handler_types[] = {
-    [NBD_BACKSTORE_GLUSTER]      = "gluster",
-    [NBD_BACKSTORE_CEPH]         = "ceph",
-
-    [NBD_BACKSTORE_MAX]          = NULL,
-};
-
-static int nbd_backstore_lookup(const char *typestring)
-{
-    int i;
-
-    if (!typestring)
-        return -1;
-
-    for (i = 0; i < NBD_BACKSTORE_MAX; i++) {
-        if (!strcmp(nbd_handler_types[i], typestring))
-            return i;
-    }
-
-    return -1;
 }
 
 typedef enum {
     NBD_OPT_HELP,
-    NBD_OPT_CREATE,
-    NBD_OPT_DELETE,
-    NBD_OPT_MAP,
-    NBD_OPT_UNMAP,
-    NBD_OPT_LIST,
     NBD_OPT_VERSION,
 
     NBD_OPT_MAX
@@ -109,11 +43,6 @@ typedef enum {
 
 static const char *const nbd_opt_commands[] = {
     [NBD_OPT_HELP]           = "help",
-    [NBD_OPT_DELETE]         = "delete",
-    [NBD_OPT_CREATE]         = "create",
-    [NBD_OPT_MAP]            = "map",
-    [NBD_OPT_UNMAP]          = "umap",
-    [NBD_OPT_LIST]           = "list",
     [NBD_OPT_VERSION]        = "version",
 
     [NBD_OPT_MAX]            = NULL,
@@ -124,826 +53,14 @@ static int nbd_command_lookup(const char *command)
     int i;
 
     if (!command)
-        return -1;
+        return NBD_OPT_MAX;
 
     for (i = 0; i < NBD_OPT_MAX; i++) {
         if (!strcmp(nbd_opt_commands[i], command))
             return i;
     }
 
-    return -1;
-}
-
-static struct addrinfo *nbd_get_sock_addr(const char *host)
-{
-  int ret;
-  struct addrinfo hints, *res;
-  char port[32];
-
-  memset(&hints, 0, sizeof hints);
-  hints.ai_family = AF_INET;
-  hints.ai_socktype = SOCK_STREAM;
-
-  snprintf(port, 32, "%d", NBD_RPC_SVC_PORT);
-
-  ret = getaddrinfo(host, port, &hints, &res);
-  if (ret) {
-    nbd_err("getaddrinfo(%s) failed (%s)", host, gai_strerror(ret));
-    return NULL;
-  }
-
-  return res;
-}
-
-static int nbd_create_file(int count, char **options, int type)
-{
-    CLIENT *clnt = NULL;
-    struct nbd_create *create;
-    struct nbd_response rep = {0,};
-    struct addrinfo *res;
-    char *host = NULL;
-    int sock = RPC_ANYSOCK;
-    int ret = 0;
-    int ind;
-    int len;
-    int max_len = 1024;
-
-    create = calloc(1, sizeof(struct nbd_create));
-    if (!create) {
-        nbd_err("No memory for nbd_create!\n");
-        return -ENOMEM;
-    }
-
-    create->type = type;
-
-    len = snprintf(create->cfgstring, max_len, "key=%s", options[2]);
-    if (len < 0) {
-        nbd_err("snprintf error for volinfo, %s!\n", strerror(errno));
-        ret = -errno;
-        goto err;
-    }
-    create->cfgstring[len++] = ';';
-
-    ind = 4;
-    while (ind < count) {
-        if (!strcmp("host", options[ind])) {
-            if (ind + 1 >= count) {
-                nbd_err("Invalid argument 'host <HOST>'!\n\n");
-                goto err;
-            }
-
-            host = strdup(options[ind + 1]);
-            if (!host) {
-                nbd_err("No memory for host!\n");
-                goto err;
-            }
-
-            ind += 2;
-        } else if (!strcmp("prealloc", options[ind])) {
-            /* prealloc --> prealloc=yes */
-            len += snprintf(create->cfgstring + len, max_len - len, "%s",
-                            options[ind]);
-            if (len < 0) {
-                nbd_err("snprintf error for prealloc, %s!\n", strerror(errno));
-                ret = -errno;
-                goto err;
-            }
-
-            create->cfgstring[len++] = '=';
-
-            len += snprintf(create->cfgstring + len, max_len - len, "%s",
-                            "yes");
-            if (len < 0) {
-                nbd_err("snprintf error for prealloc value, %s!\n",
-                        strerror(errno));
-                ret = -errno;
-                goto err;
-            }
-
-            create->cfgstring[len++] = ';';
-            ind += 1;
-        } else if (!strcmp("size", options[ind])) {
-            if (ind + 1 >= count) {
-                nbd_err("Invalid argument 'size <SIZE>'!\n\n");
-                goto err;
-            }
-
-            if (!nbd_valid_size(options[ind + 1])) {
-                nbd_err("Invalid size!\n");
-                ret = -EINVAL;
-                goto err;
-            }
-
-            len += snprintf(create->cfgstring + len, max_len - len, "%s",
-                            options[ind]);
-            if (len < 0) {
-                nbd_err("snprintf error for prealloc, %s!\n", strerror(errno));
-                ret = -errno;
-                goto err;
-            }
-
-            create->cfgstring[len++] = '=';
-
-            len += snprintf(create->cfgstring + len, max_len - len,
-                            "%s", options[ind + 1]);
-            if (len < 0) {
-                nbd_err("snprintf error for prealloc value, %s!\n",
-                        strerror(errno));
-                ret = -errno;
-                goto err;
-            }
-
-            create->cfgstring[len++] = ';';
-            ind += 2;
-        } else {
-            nbd_err("Invalid option : %s\n", options[ind]);
-            ret = -EINVAL;
-            goto err;
-        }
-    }
-
-    if (!host) {
-        nbd_err("<host HOST> param is a must here!\n");
-        goto err;
-    }
-
-    res = nbd_get_sock_addr(host);
-    if (!res) {
-        nbd_err("failed to get sock addr!\n");
-        goto err;
-    }
-
-    clnt = clnttcp_create((struct sockaddr_in *)res->ai_addr, RPC_NBD,
-                          RPC_NBD_VERS, &sock, 0, 0);
-    if (!clnt) {
-        nbd_err("clnttcp_create failed, %s!\n", strerror(errno));
-        goto err;
-    }
-
-    if (nbd_create_1(create, &rep, clnt) != RPC_SUCCESS) {
-        nbd_err("nbd_create_1 failed!\n");
-        goto err;
-    }
-
-    ret = rep.exit;
-    if (ret && rep.out)
-        nbd_err("Create failed: %s\n", rep.out);
-    else
-        nbd_out("Create succeeded!\n");
-
-err:
-    if (clnt) {
-        if (rep.out && !clnt_freeres(clnt, (xdrproc_t)xdr_nbd_response,
-                                     (char *)&rep))
-            nbd_err("clnt_freeres failed!\n");
-        clnt_destroy(clnt);
-    }
-
-    free(host);
-    free(create);
-    return ret;
-}
-
-static int nbd_delete_file(int count, char **options, int type)
-{
-    CLIENT *clnt = NULL;
-    struct nbd_delete *delete;
-    struct nbd_response rep = {0,};
-    struct addrinfo *res;
-    char *host = NULL;
-    int sock = RPC_ANYSOCK;
-    int ret = 0;
-    int len;
-    int max_len = 1024;
-
-    delete = calloc(1, sizeof(struct nbd_delete));
-    if (!delete) {
-        nbd_err("No memory for nbd_delete!\n");
-        return -ENOMEM;
-    }
-
-    delete->type = type;
-
-    len = snprintf(delete->cfgstring, max_len, "key=%s", options[3]);
-    if (len < 0) {
-        ret = -errno;
-        nbd_err("snprintf error for volinfo, %s!\n", strerror(errno));
-        goto err;
-    }
-
-    if (!strcmp("host", options[4])) {
-        if (count < 5) {
-            nbd_err("Invalid argument 'host <HOST>'!\n\n");
-            goto err;
-        }
-
-        host = strdup(options[5]);
-        if (!host) {
-            ret = -ENOMEM;
-            nbd_err("No memory for host!\n");
-            goto err;
-        }
-    }
-
-    if (!host) {
-        nbd_err("<host HOST> param is a must here!\n");
-        goto err;
-    }
-
-    res = nbd_get_sock_addr(host);
-    if (!res) {
-        ret = -ENOMEM;
-        nbd_err("failed to get sock addr!\n");
-        goto err;
-    }
-
-    clnt = clnttcp_create((struct sockaddr_in *)res->ai_addr, RPC_NBD,
-                          RPC_NBD_VERS, &sock, 0, 0);
-    if (!clnt) {
-        ret = -errno;
-        nbd_err("clnttcp_create failed, %s!\n", strerror(errno));
-        goto err;
-    }
-
-    if (nbd_delete_1(delete, &rep, clnt) != RPC_SUCCESS) {
-        ret = -errno;
-        nbd_err("nbd_delete_1 failed!\n");
-        goto err;
-    }
-
-    ret = rep.exit;
-    if (ret && rep.out)
-        nbd_err("Delete failed: %s\n", rep.out);
-    else
-        nbd_out("Delete succeeded!\n");
-
-err:
-    if (clnt) {
-        if (rep.out && !clnt_freeres(clnt, (xdrproc_t)xdr_nbd_response,
-                                     (char *)&rep))
-            nbd_err("clnt_freeres failed!\n");
-        clnt_destroy(clnt);
-    }
-
-    free(host);
-    free(delete);
-    return ret;
-}
-
-typedef enum {
-    NBD_LIST_MAPPED,
-    NBD_LIST_UNMAPPED,
-    NBD_LIST_ALL,
-} list_type;
-
-static int nbd_list_type = NBD_LIST_ALL;
-
-static struct nla_policy nbd_device_policy[NBD_DEVICE_ATTR_MAX + 1] = {
-    [NBD_DEVICE_INDEX]              =       { .type = NLA_U32 },
-    [NBD_DEVICE_CONNECTED]          =       { .type = NLA_U8 },
-};
-
-static int map_nl_callback(struct nl_msg *msg, void *arg)
-{
-    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-    struct nlattr *msg_attr[NBD_ATTR_MAX + 1];
-    uint32_t index;
-    int ret;
-
-    if (nla_parse(msg_attr, NBD_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-                  genlmsg_attrlen(gnlh, 0), NULL) < 0) {
-        nbd_err("Invalid response from the kernel\n");
-        return NL_STOP;
-    }
-
-    if (!msg_attr[NBD_ATTR_INDEX]) {
-        nbd_err("Did not receive index from the kernel\n");
-        return NL_STOP;
-    }
-
-    index = nla_get_u32(msg_attr[NBD_ATTR_INDEX]);
-    nbd_out("Connected /dev/nbd%d\n", (int)index);
-
-    return NL_OK;
-}
-
-static int list_nl_callback(struct nl_msg *msg, void *arg)
-{
-    struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-    struct nlattr *msg_attr[NBD_ATTR_MAX + 1];
-    uint32_t index;
-    struct nlattr *attr;
-    int rem;
-    int status;
-
-    if (nla_parse(msg_attr, NBD_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-                  genlmsg_attrlen(gnlh, 0), NULL) < 0) {
-        nbd_err("Invalid response from the kernel\n");
-        return NL_STOP;
-    }
-
-    if (!msg_attr[NBD_ATTR_DEVICE_LIST]) {
-        nbd_err("NBD_ATTR_DEVICE_LIST not set in cmd!\n");
-        return NL_STOP;
-    }
-
-    nla_for_each_nested(attr, msg_attr[NBD_ATTR_DEVICE_LIST], rem) {
-        struct nlattr *devices[NBD_DEVICE_ATTR_MAX + 1];
-
-        if (nla_type(attr) != NBD_DEVICE_ITEM) {
-            nbd_err("NBD_DEVICE_ITEM not set!\n");
-            return NL_STOP;
-        }
-
-        if (nla_parse_nested(devices, NBD_DEVICE_ATTR_MAX, attr,
-                             nbd_device_policy) < 0) {
-            nbd_err("nbd: error processing device list\n");
-            return NL_STOP;
-        }
-
-        index = (int)nla_get_u32(devices[NBD_DEVICE_INDEX]);
-        status = (int)nla_get_u8(devices[NBD_DEVICE_CONNECTED]);
-
-        switch (nbd_list_type) {
-        case NBD_LIST_MAPPED:
-            if (status)
-                nbd_out("/dev/nbd%d \t%s\n", index, "Mapped");
-            break;
-        case NBD_LIST_UNMAPPED:
-            if (!status)
-                nbd_out("/dev/nbd%d \t%s\n", index, "Unmapped");
-            break;
-        case NBD_LIST_ALL:
-            nbd_out("/dev/nbd%d \t%s\n", index,
-                    status ? "Mapped" : "Unmapped");
-            break;
-        default:
-            nbd_err("Invalid list type: %d!\n", nbd_list_type);
-            return NL_STOP;
-        }
-    }
-
-    return NL_OK;
-}
-
-static struct nl_sock *nbd_setup_netlink(int *driver_id, int cmd)
-{
-    int (*nl_callback_fn)(struct nl_msg *, void *);
-    struct nl_sock *netfd;
-
-    if (!driver_id)
-        return NULL;
-
-    netfd = nl_socket_alloc();
-    if (!netfd) {
-        nbd_err("Couldn't alloc socket, %s!\n", strerror(errno));
-        return NULL;
-    }
-
-    switch (cmd) {
-    case NBD_OPT_MAP:
-        nl_callback_fn = map_nl_callback;
-        break;
-    case NBD_OPT_LIST:
-        nl_callback_fn = list_nl_callback;
-        break;
-    case NBD_OPT_UNMAP:
-    default:
-        nl_callback_fn = genl_handle_msg;
-    }
-
-    nl_socket_modify_cb(netfd, NL_CB_VALID, NL_CB_CUSTOM, nl_callback_fn, NULL);
-
-    if (genl_connect(netfd)) {
-        nbd_err("Couldn't connect to the nbd netlink socket, %s!\n",
-                strerror(errno));
-        goto err;
-    }
-
-    *driver_id = genl_ctrl_resolve(netfd, "nbd");
-    if (*driver_id < 0) {
-        nbd_err("Couldn't resolve the nbd netlink family, %s!\n",
-                strerror(errno));
-        goto err;
-    }
-
-    return netfd;
-err:
-    nl_socket_free(netfd);
-    return NULL;
-}
-
-static int nbd_device_connect(char *cfg, struct nl_sock *netfd, int sockfd,
-                              int driver_id, ssize_t size, ssize_t blk_size,
-                              int timeout, int dev_index, bool readonly)
-{
-    struct nlattr *sock_attr;
-    struct nlattr *sock_opt;
-    struct nl_msg *msg;
-    int flags = readonly ? NBD_FLAG_READ_ONLY : 0;
-    struct nego_request nhdr;
-    struct nego_reply nrep;
-    char *buf;
-
-    printf("lxb size: %llu, blk_size: %llu\n", size, blk_size);
-    nhdr.len = strlen(cfg);
-    nbd_socket_write(sockfd, &nhdr, sizeof(struct nego_request));
-    nbd_socket_write(sockfd, cfg, nhdr.len);
-
-    nbd_socket_read(sockfd, &nrep, sizeof(struct nego_reply));
-    if (nrep.exit) {
-        if (nrep.len) {
-            buf = malloc(nrep.len + 1);
-            nbd_socket_read(sockfd, &buf, nrep.len);
-            nbd_err("nego failed: %s, %d\n", buf, nrep.exit);
-            free(buf);
-        } else {
-            nbd_err("nego failed: %d\n", buf, nrep.exit);
-        }
-        goto nla_put_failure;
-    }
-
-    msg = nlmsg_alloc();
-    if (!msg) {
-        nbd_err("Couldn't allocate netlink message, %s!\n",
-                strerror(errno));
-        goto nla_put_failure;
-    }
-
-    genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0,
-            NBD_CMD_CONNECT, 0);
-
-    /* -1 means alloc the device dynamically */
-    if (dev_index < -1)
-        dev_index = -1;
-    NLA_PUT_U32(msg, NBD_ATTR_INDEX, dev_index);
-    NLA_PUT_U64(msg, NBD_ATTR_SIZE_BYTES, size);
-    NLA_PUT_U64(msg, NBD_ATTR_BLOCK_SIZE_BYTES,
-                blk_size ? blk_size : NBD_DEFAULT_SECTOR_SIZE);
-    NLA_PUT_U64(msg, NBD_ATTR_SERVER_FLAGS, flags);
-    if (timeout)
-        NLA_PUT_U64(msg, NBD_ATTR_TIMEOUT, timeout);
-
-    sock_attr = nla_nest_start(msg, NBD_ATTR_SOCKETS);
-    if (!sock_attr) {
-        nbd_err("Couldn't nest the socket!\n");
-        goto nla_put_failure;
-    }
-    sock_opt = nla_nest_start(msg, NBD_SOCK_ITEM);
-    if (!sock_opt) {
-        nbd_err("Couldn't nest the socket item!\n");
-        goto nla_put_failure;
-    }
-
-    NLA_PUT_U32(msg, NBD_SOCK_FD, sockfd);
-    nla_nest_end(msg, sock_opt);
-    nla_nest_end(msg, sock_attr);
-
-    if (nl_send_sync(netfd, msg) < 0) {
-        nbd_err("Failed to setup device, check dmesg!\n");
-        goto nla_put_failure;
-    }
-
-    return 0;
-
-nla_put_failure:
-    return -1;
-}
-
-static int nbd_connect_to_server(char *host, int port)
-{
-    struct sockaddr_in addr;
-    int sock;
-    int ret;
-
-    if (!host || port < 0) {
-        nbd_err("Invalid host or port param!\n");
-        return -1;
-    }
-
-    sock = socket(AF_INET, SOCK_STREAM, 0);
-    if(sock < 0){
-        nbd_err("failed to create socket: %s\n", strerror(errno));
-        return -1;
-    }
-
-    bzero(&addr, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = inet_addr(host);
-    addr.sin_port = htons(port);
-
-    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        nbd_err("connect error: %s\n", strerror(errno));
-        goto err;
-    }
-
-    return sock;
-
-err:
-    close(sock);
-    return -1;
-}
-
-static int _nbd_map_device(char *cfg, struct nbd_response *rep, int dev_index,
-                           int timeout, bool readonly)
-{
-    int ret;
-    int sockfd;
-    struct nl_sock *netfd;
-    int driver_id;
-
-    /* Connect to server for IOs */
-    sockfd = nbd_connect_to_server(rep->host, atoi(rep->port));
-    if (sockfd < 0)
-        return -1;
-
-    /* Setup netlink to configure the nbd device */
-    netfd = nbd_setup_netlink(&driver_id, NBD_OPT_MAP);
-    if (!netfd)
-        return -1;
-
-    /* Setup the IOs sock fd to nbd device to start IOs */
-    ret = nbd_device_connect(cfg, netfd, sockfd, driver_id, rep->size,
-                             rep->blksize, timeout, dev_index, readonly);
-
-    if (!ret)
-        return 0;
-
-err:
-    close(sockfd);
-    nl_socket_free(netfd);
-    return -1;
-}
-
-static int nbd_map_device(int count, char **options, int type)
-{
-    CLIENT *clnt = NULL;
-    struct nbd_map *map;
-    struct nbd_response rep = {0,};
-    struct addrinfo *res;
-    char *host = NULL;
-    int sock = RPC_ANYSOCK;
-    int dev_index = -1;
-    int timeout = 0;
-    bool readonly = false;
-    int ret = 0;
-    int len;
-    int ind;
-    int max_len = 1024;
-
-    map = calloc(1, sizeof(struct nbd_map));
-    if (!map) {
-        nbd_err("No memory for nbd_map!\n");
-        return -ENOMEM;
-    }
-
-    map->type = type;
-
-    len = snprintf(map->cfgstring, max_len, "key=%s", options[3]);
-    if (len < 0) {
-        ret = -errno;
-        nbd_err("snprintf error for volinfo, %s!\n", strerror(errno));
-        goto err;
-    }
-
-    map->cfgstring[len++] = ';';
-
-    ind = 4;
-    while (ind < count) {
-        if (!strncmp("/dev/nbd", options[ind], strlen("/dev/nbd"))) {
-            if (sscanf(options[ind], "/dev/nbd%d", &dev_index) != 1) {
-                ret = -errno;
-                nbd_err("Invalid nbd-device!\n");
-                goto err;
-            }
-
-            ind += 1;
-        } else if (!strcmp("host", options[ind])) {
-            if (ind + 1 >= count) {
-                nbd_err("Invalid argument 'host <HOST>'!\n\n");
-                goto err;
-            }
-
-            host = strdup(options[ind + 1]);
-            if (!host) {
-                ret = -ENOMEM;
-                nbd_err("No memory for host!\n");
-                goto err;
-            }
-
-            ind += 2;
-        } else if (!strcmp("readonly", options[ind])) {
-            readonly = true;
-
-            /* prealloc yes --> prealloc=yes */
-            len += snprintf(map->cfgstring + len, max_len - len, "%s",
-                            options[ind]);
-            if (len < 0) {
-                nbd_err("snprintf error for readonly, %s!\n", strerror(errno));
-                ret = -errno;
-                goto err;
-            }
-
-            map->cfgstring[len++] = '=';
-
-            len += snprintf(map->cfgstring + len, max_len - len, "%s",
-                            "yes");
-            if (len < 0) {
-                nbd_err("snprintf error for readonly value, %s!\n",
-                        strerror(errno));
-                ret = -errno;
-                goto err;
-            }
-
-            map->cfgstring[len++] = ';';
-            ind += 1;
-        } else if (!strcmp("timeout", options[ind])) {
-            if (ind + 1 >= count) {
-                nbd_err("Invalid argument 'timeout <TIME>'!\n\n");
-                goto err;
-            }
-
-            timeout = atoi(options[ind + 1]);
-            if (timeout < 0) {
-                ret = -EINVAL;
-                nbd_err("Invalid timeout value!\n");
-                goto err;
-            }
-
-            ind += 2;
-        } else {
-            ret = -EINVAL;
-            nbd_err("Invalid argument '%s'!\n", options[ind]);
-            goto err;
-        }
-    }
-
-    if (!host) {
-        nbd_err("<host HOST> param is a must here!\n");
-        goto err;
-    }
-
-    res = nbd_get_sock_addr(host);
-    if (!res) {
-        ret = -ENOMEM;
-        nbd_err("failed to get sock addr!\n");
-        goto err;
-    }
-
-    clnt = clnttcp_create((struct sockaddr_in *)res->ai_addr, RPC_NBD,
-                          RPC_NBD_VERS, &sock, 0, 0);
-    if (!clnt) {
-        ret = -errno;
-        nbd_err("clnttcp_create failed, %s!\n", strerror(errno));
-        goto err;
-    }
-
-    if (nbd_map_1(map, &rep, clnt) != RPC_SUCCESS) {
-        ret = -errno;
-        nbd_err("nbd_map_1 failed!\n");
-        goto err;
-    }
-
-    ret = rep.exit;
-    if (ret && rep.out) {
-        nbd_err("Map failed: %s\n", rep.out);
-        goto err;
-    }
-
-    /* create the /dev/nbdX device */
-    ret = _nbd_map_device(map->cfgstring, &rep, dev_index, timeout, readonly);
-    if (ret < 0) {
-        nbd_err("failed to init the /dev/nbd device!\n");
-        goto err;
-    }
-
-    nbd_out("Map succeeded!\n");
-
-err:
-    if (clnt) {
-        if (rep.out && !clnt_freeres(clnt, (xdrproc_t)xdr_nbd_response,
-                                     (char *)&rep))
-            nbd_err("clnt_freeres failed!\n");
-        clnt_destroy(clnt);
-    }
-
-    free(host);
-    free(map);
-    return ret;
-}
-
-static int
-umap_device(struct nl_sock *netfd, int driver_id, int index)
-{
-    struct nl_msg *msg;
-    int ret = 0;
-
-    msg = nlmsg_alloc();
-    if (!msg) {
-        nbd_err("Couldn't allocate netlink message!\n");
-        ret = -1;
-        goto nla_put_failure;
-    }
-
-    genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0,
-            NBD_CMD_DISCONNECT, 0);
-    NLA_PUT_U32(msg, NBD_ATTR_INDEX, index);
-    if (nl_send_sync(netfd, msg) < 0) {
-        nbd_err("Failed to disconnect device, check dmsg\n");
-        ret = -1;
-    }
-
-    nbd_out("Unmap succeeded!\n");
-
-nla_put_failure:
-    return ret;
-}
-
-static int
-nbd_umap_device(int count, char **options, int type)
-{
-    struct nl_sock *netfd;
-    int driver_id;
-    int index = -1;
-
-    if (count != 4) {
-        nbd_err("Invalid arguments for umap command!\n");
-        return -1;
-    }
-
-    if (sscanf(options[3], "/dev/nbd%d", &index) != 1) {
-        nbd_err("Invalid nbd device target!\n");
-        return -1;
-    }
-
-    if (index < 0) {
-        nbd_err("Invalid nbd device target!\n");
-        return -1;
-    }
-
-    netfd = nbd_setup_netlink(&driver_id, NBD_OPT_UNMAP);
-    if (!netfd)
-        return -1;
-
-    return umap_device(netfd, driver_id, index);
-}
-
-static int nbd_devices_query(struct nl_sock *netfd, int driver_id)
-{
-    struct nl_msg *msg;
-
-    msg = nlmsg_alloc();
-    if (!msg) {
-        nbd_err("Couldn't allocate netlink message, %s!\n",
-                strerror(errno));
-        goto nla_put_failure;
-    }
-
-    genlmsg_put(msg, NL_AUTO_PORT, NL_AUTO_SEQ, driver_id, 0, 0,
-            NBD_CMD_STATUS, 0);
-    /*
-     * -1 means list all the devices mapped and
-     *  umapped in kernel space
-     */
-    NLA_PUT_U32(msg, NBD_ATTR_INDEX, -1);
-
-    if (nl_send_sync(netfd, msg) < 0)
-        nbd_err("Failed to setup device, check dmesg\n");
-
-    return 0;
-
-nla_put_failure:
-    nl_socket_free(netfd);
-    return -1;
-}
-
-static int
-nbd_list_devices(int count, char **options, int type)
-{
-    struct nl_sock *netfd;
-    int driver_id;
-
-    if (count != 4) {
-        nbd_err("Invalid arguments for list command!\n");
-        return -1;
-    }
-
-    if (!strcmp(options[3], "map")) {
-        nbd_list_type = NBD_LIST_MAPPED;
-    } else if (!strcmp(options[3], "umap")) {
-        nbd_list_type = NBD_LIST_UNMAPPED;
-    } else if (!strcmp(options[3], "all")) {
-        nbd_list_type = NBD_LIST_ALL;
-    } else {
-        nbd_err("Invalid argument for list!\n");
-        return -1;
-    }
-
-    netfd = nbd_setup_netlink(&driver_id, NBD_OPT_LIST);
-    if (!netfd)
-        return -1;
-
-    return nbd_devices_query(netfd, driver_id);
+    return NBD_OPT_MAX;
 }
 
 static int load_our_module(void)
@@ -1043,84 +160,76 @@ static int load_our_module(void)
 
 int main(int argc, char *argv[])
 {
-    int ex = EXIT_SUCCESS;
+    GHashTable *cmds_hash = NULL;
     nbd_opt_command cmd;
+    struct cli_cmd *clicmd;
+    int ret = EXIT_FAILURE;
+    char *key = NULL;
     int type;
-    int ret;
+    int len;
 
     nbd_log_init();
+
+    if (argc == 1) {
+        usage();
+        ret = EXIT_SUCCESS;
+        goto out;
+    }
+
+    if (argc == 2) {
+        cmd = nbd_command_lookup(argv[1]);
+
+        ret = EXIT_SUCCESS;
+        switch(cmd) {
+        case NBD_OPT_HELP:
+            usage();
+            goto out;
+        case NBD_OPT_VERSION:
+            _nbd_out("%s\n", nbd_version_info);
+            goto out;
+        case NBD_OPT_MAX:
+        default:
+            break;
+        }
+    }
 
     if (!nbd_minimal_kernel_version_check())
         goto out;
 
-    if (argc <= 1) {
-        usage();
-        ex = EXIT_FAILURE;
-        goto out;
-    }
-
     if (load_our_module() < 0)
         goto out;
 
-    type = nbd_backstore_lookup(argv[1]);
-    if (type < 0) {
-        if (strcmp(argv[1], "version") && strcmp(argv[1], "help")) {
-            nbd_err("Invalid backstore type: %s\n", argv[1]);
-            goto out;
-        }
-        cmd = nbd_command_lookup(argv[1]);
-    } else {
-
-        cmd = nbd_command_lookup(argv[2]);
-    }
-    if (cmd < 0) {
-        nbd_err("Invalid command!\n\n" );
-        usage();
-        ex = EXIT_FAILURE;
+    cmds_hash = nbd_register_backstores();
+    if (!cmds_hash) {
+        nbd_err("No command registered!\n");
         goto out;
     }
 
-    switch(cmd) {
-    case NBD_OPT_HELP:
-        usage();
-        goto out;
-    case NBD_OPT_CREATE:
-        ret = nbd_create_file(argc, argv, type);
-        if (ret < 0)
-                ex = EXIT_FAILURE;
-        break;
-    case NBD_OPT_DELETE:
-        ret = nbd_delete_file(argc, argv, type);
-        if (ret < 0)
-                ex = EXIT_FAILURE;
-        break;
-    case NBD_OPT_MAP:
-        ret = nbd_map_device(argc, argv, type);
-        if (ret < 0)
-                ex = EXIT_FAILURE;
-        break;
-    case NBD_OPT_UNMAP:
-        ret = nbd_umap_device(argc, argv, type);
-        if (ret < 0)
-                ex = EXIT_FAILURE;
-        break;
-    case NBD_OPT_LIST:
-        ret = nbd_list_devices(argc, argv, type);
-        if (ret < 0)
-                ex = EXIT_FAILURE;
-        break;
-    case NBD_OPT_VERSION:
-        _nbd_out("%s\n", nbd_version_info);
-        break;
-    case NBD_OPT_MAX:
-    default:
-        nbd_err("Invalid command!\n");
-        usage();
-        ex = EXIT_FAILURE;
+    key = calloc(1, 1024);
+    if (!key) {
+        nbd_err("No memory for key!\n");
         goto out;
     }
 
+    /* The hash key will be "backstore_type cmd" */
+    len = snprintf(key, 1024, "%s", argv[1]);
+    if (argc > 2)
+        snprintf(key + len, 1024 - len, " %s", argv[2]);
+
+    clicmd = g_hash_table_lookup(cmds_hash, key);
+    if (!clicmd) {
+        nbd_err("Invalid command: %s\n", key);
+        goto out;
+    }
+
+    if (clicmd->call(argc - 3, argc > 3 ? argv + 3 : NULL) < 0) {
+        goto out;
+    }
+
+    ret = EXIT_SUCCESS;
 out:
+    free(key);
+    nbd_unregister_backstores(cmds_hash);
     nbd_log_destroy();
-    exit(ex);
+    exit(ret);
 }

--- a/daemon/gluster.c
+++ b/daemon/gluster.c
@@ -544,7 +544,7 @@ static void glfs_handle_request(gpointer data, gpointer user_data)
 
 struct nbd_handler glfs_handler = {
     .name           = "Gluster gfapi handler",
-    .subtype        = NBD_HANDLER_GLUSTER,
+    .subtype        = NBD_BACKSTORE_GLUSTER,
 
     .lock           = PTHREAD_MUTEX_INITIALIZER,
 

--- a/daemon/nbd-common.h
+++ b/daemon/nbd-common.h
@@ -47,11 +47,13 @@ struct nbd_handler {
 
     void *data;		/* Handler private data. */
 
-    struct nbd_device *(*cfg_parse)(const char *, nbd_response *);
+    bool (*cfg_parse)(struct nbd_device *, const char *, nbd_response *);
     bool (*create)(struct nbd_device *, nbd_response *);
     bool (*delete)(struct nbd_device *, nbd_response *);
     bool (*map)(struct nbd_device *, nbd_response *);
     bool (*unmap)(struct nbd_device *);
+    ssize_t (*get_size)(struct nbd_device *, nbd_response *);
+    ssize_t (*get_blksize)(struct nbd_device *, nbd_response *);
     void (*handle_request)(gpointer, gpointer);
 };
 

--- a/daemon/nbd-svc-routines.c
+++ b/daemon/nbd-svc-routines.c
@@ -78,9 +78,10 @@ bool_t nbd_create_1_svc(nbd_create *create, nbd_response *rep,
     if (!handler) {
         rep->exit = -EINVAL;
         snprintf(rep->out, NBD_EXIT_MAX,
-                 "Invalid handler or the handler is not loaded: %s!",
+                 "Invalid handler or the handler is not loaded: %d!",
                  create->type);
-        nbd_err("Invalid handler or the handler is not loaded: %s!", create->type);
+        nbd_err("Invalid handler or the handler is not loaded: %d!",
+                create->type);
         goto err;
     }
 
@@ -149,9 +150,10 @@ bool_t nbd_delete_1_svc(nbd_delete *delete, nbd_response *rep,
     if (!handler) {
         rep->exit = -EINVAL;
         snprintf(rep->out, NBD_EXIT_MAX,
-                 "Invalid handler or the handler is not loaded: %s!",
+                 "Invalid handler or the handler is not loaded: %d!",
                  delete->type);
-        nbd_err("Invalid handler or the handler is not loaded: %s!", delete->type);
+        nbd_err("Invalid handler or the handler is not loaded: %d!",
+                delete->type);
         goto err;
     }
 
@@ -214,9 +216,10 @@ bool_t nbd_map_1_svc(nbd_map *map, nbd_response *rep, struct svc_req *req)
     if (!handler) {
         rep->exit = -EINVAL;
         snprintf(rep->out, NBD_EXIT_MAX,
-                 "Invalid handler or the handler is not loaded: %s!",
+                 "Invalid handler or the handler is not loaded: %d!",
                  map->type);
-        nbd_err("Invalid handler or the handler is not loaded: %s!", map->type);
+        nbd_err("Invalid handler or the handler is not loaded: %d!",
+                map->type);
         goto err;
     }
 

--- a/daemon/nbd-svc-routines.c
+++ b/daemon/nbd-svc-routines.c
@@ -102,14 +102,23 @@ bool_t nbd_create_1_svc(nbd_create *create, nbd_response *rep,
         goto err;
     }
 
-    dev = handler->cfg_parse(create->cfgstring, rep);
+    dev = calloc(1, sizeof(struct nbd_device));
     if (!dev) {
+        rep->exit = -ENOMEM;
+        snprintf(rep->out, NBD_EXIT_MAX, "No memory for nbd_device!");
+        nbd_err("No memory for nbd_device!\n");
+        goto err;
+    }
+
+    if (!handler->cfg_parse(dev, create->cfgstring, rep)) {
         nbd_err("failed to parse cfgstring: %s\n", create->cfgstring);
-        free(key);
         goto err;
     }
 
     dev->handler = handler;
+    dev->size = create->size;
+    dev->prealloc = create->prealloc;
+
 
     /*
      * Since we allow to create the backstore directly
@@ -119,14 +128,20 @@ bool_t nbd_create_1_svc(nbd_create *create, nbd_response *rep,
      */
     if (!handler->create(dev, rep) && rep->exit != -EEXIST) {
         nbd_err("failed to create backstore: %s\n", create->cfgstring);
-        handler->delete(dev, rep);
-        free(key);
         goto err;
     }
 
+    dev->blksize = handler->get_blksize(dev, NULL);
+    if (dev->blksize < 0)
+        goto err;
     g_hash_table_insert(nbd_devices_hash, key, dev);
 
 err:
+    if (rep->exit && rep->exit != -EEXIST) {
+        free(key);
+        handler->delete(dev, rep);
+        free(dev);
+    }
     return true;
 }
 
@@ -176,19 +191,25 @@ bool_t nbd_delete_1_svc(nbd_delete *delete, nbd_response *rep,
          */
         nbd_out("%s is not in the hash table, will try to delete enforce!\n",
                 delete->cfgstring);
-        dev = handler->cfg_parse(delete->cfgstring, rep);
+        dev = calloc(1, sizeof(struct nbd_device));
         if (!dev) {
+            rep->exit = -ENOMEM;
+            snprintf(rep->out, NBD_EXIT_MAX, "No memory for nbd_device!");
+            nbd_err("No memory for nbd_device!\n");
+            goto err;
+        }
+
+        if (!handler->cfg_parse(dev, delete->cfgstring, rep)) {
             rep->exit = -EAGAIN;
             snprintf(rep->out, NBD_EXIT_MAX, "failed to delete %s!", delete->cfgstring);
             nbd_err("failed to delete %s\n", delete->cfgstring);
             goto err;
         }
         dev->handler = handler;
-    } else {
-        g_hash_table_remove(nbd_devices_hash, key);
     }
 
     handler->delete(dev, rep);
+    g_hash_table_remove(nbd_devices_hash, key);
 
 err:
     free(key);
@@ -242,15 +263,30 @@ bool_t nbd_map_1_svc(nbd_map *map, nbd_response *rep, struct svc_req *req)
         need_to_insert = true;
         nbd_out("%s is not in the hash table, will try to map enforce!\n",
                 map->cfgstring);
-        dev = handler->cfg_parse(map->cfgstring, rep);
+        dev = calloc(1, sizeof(struct nbd_device));
         if (!dev) {
+            rep->exit = -ENOMEM;
+            snprintf(rep->out, NBD_EXIT_MAX, "No memory for nbd_device!");
+            nbd_err("No memory for nbd_device!\n");
+            goto err;
+        }
+
+        if (!handler->cfg_parse(dev, map->cfgstring, rep)) {
             rep->exit = -EAGAIN;
             snprintf(rep->out, NBD_EXIT_MAX, "failed to map %s!", map->cfgstring);
             nbd_err("failed to map %s\n", map->cfgstring);
             free(key);
             goto err;
         }
+
         dev->handler = handler;
+        dev->readonly = map->readonly;
+        dev->size = handler->get_size(dev, rep);
+        if (dev->size < 0)
+            goto err;
+        dev->blksize = handler->get_blksize(dev, rep);
+        if (dev->blksize < 0)
+            goto err;
     }
 
     if (!handler->map(dev, rep)) {
@@ -472,6 +508,11 @@ void free_key(gpointer key)
     free(key);
 }
 
+void free_value(gpointer value)
+{
+    free(value);
+}
+
 bool nbd_service_init(void)
 {
     nbd_handler_hash = g_hash_table_new(g_int_hash, g_int_equal);
@@ -481,7 +522,7 @@ bool nbd_service_init(void)
     }
 
     nbd_devices_hash = g_hash_table_new_full(g_str_hash, g_str_equal, free_key,
-                                             NULL);
+                                             free_value);
     if (!nbd_devices_hash) {
         nbd_err("failed to create nbd_devices_hash hash table!\n");
         return false;

--- a/rpc/rpc_nbd.x
+++ b/rpc/rpc_nbd.x
@@ -4,9 +4,10 @@
 #endif
 
 enum handler_t {
-    NBD_HANDLER_GLUSTER     = 0,
+    NBD_BACKSTORE_GLUSTER,
+    NBD_BACKSTORE_CEPH,
 
-    NBD_HANDLER_MAX
+    NBD_BACKSTORE_MAX
 };
 
 #define HOST_MAX  255

--- a/rpc/rpc_nbd.x
+++ b/rpc/rpc_nbd.x
@@ -15,50 +15,49 @@ enum handler_t {
 #define PORT_MAX  32
 
 struct nbd_create {
-  handler_t     type;
-  char          host[HOST_MAX];
-  char          cfgstring[CFGS_MAX];
+    handler_t     type;
+    u_quad_t      size;
+    bool          prealloc;
+    char          cfgstring[CFGS_MAX];
 };
 
 struct nbd_delete {
-  handler_t     type;
-  char          host[HOST_MAX];
-  char          cfgstring[CFGS_MAX];
+    handler_t     type;
+    char          cfgstring[CFGS_MAX];
 };
 
 struct nbd_map {
-  handler_t     type;
-  char          host[HOST_MAX];
-  char          cfgstring[CFGS_MAX];
-  int           threads;
+    handler_t     type;
+    bool          readonly;
+    char          cfgstring[CFGS_MAX];
 };
 
 struct nbd_response {
-  int           exit;
-  string        out<>;
+    int           exit;
+    string        out<>;
 
-  /*
-   * The following members will only be
-   * used by the map option.
-   *
-   * host : the server listen ip address
-   * port : the server listen tcp port
-   * size : the backend file/block size
-   * blksize: the backend file/block sector size
-   */
-  char          host[HOST_MAX];
-  char          port[PORT_MAX];
-  u_quad_t      size;
-  u_quad_t      blksize;
+    /*
+     * The following members will only be
+     * used by the map option.
+     *
+     * host : the server listen ip address
+     * port : the server listen tcp port
+     * size : the backend file/block size
+     * blksize: the backend file/block sector size
+     */
+    char          host[HOST_MAX];
+    char          port[PORT_MAX];
+    u_quad_t      size;
+    u_quad_t      blksize;
 
 };
 
 #define RPC1_RPC_PROG_NUM 0x3f0a37eb
 
 program RPC_NBD {
-  version RPC_NBD_VERS {
-    nbd_response NBD_CREATE(nbd_create) = 1;
-    nbd_response NBD_DELETE(nbd_delete) = 2;
-    nbd_response NBD_MAP(nbd_map) = 3;
-  } = 1;
+    version RPC_NBD_VERS {
+        nbd_response NBD_CREATE(nbd_create) = 1;
+        nbd_response NBD_DELETE(nbd_delete) = 2;
+        nbd_response NBD_MAP(nbd_map) = 3;
+    } = 1;
 } = RPC1_RPC_PROG_NUM;


### PR DESCRIPTION
This idea comes from the glusterfs project's cli code.

Usage:
 gluster help		-display help for gluster commands
 ceph help		-display help for ceph commands, TODO
 global help		-display help for global commands, TODO
 version		-display the version of nbd-cli

Usage:

	gluster help
		display help for gluster commands
	gluster create <volname@host:/path> [prealloc] <size SIZE> <host HOST>
		create path file on the volname volume, prealloc is false as default, and the SIZE is valid with B, K(iB), M(iB), G(iB), T(iB), P(iB), E(iB), Z(iB), Y(iB)
	gluster delete <volname@host:/path> <host HOST>
		delete path file on the volname volume
	gluster map <volname@host:/path> [nbd-device] [timeout TIME] <host HOST> [readonly]
		map path file to the nbd device, as default the timeout 0, none readonly
	gluster unmap <nbd-device>
		unmap the nbd device
	gluster list <map|unmap|all>
		list the mapped|unmapped|all nbd devices, all as default
