### PR TITLE
nbd-runner: save the backstore config to the saveconfig.json

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,11 @@ AC_ARG_WITH(sysconfigdir,
             [sysconfigdir='/etc/sysconfig'])
 AC_SUBST(sysconfigdir)
 
+PKG_CHECK_MODULES([JSONC], [json-c],,
+                  [AC_MSG_ERROR([json-c library is required to build nbd-runner])])
+AC_SUBST(JSONC_CFLAGS)
+AC_SUBST(JSONC_LIBS)  
+
 PKG_CHECK_MODULES(KMOD, [libkmod],,
                   [AC_MSG_ERROR([kmod library is required to build nbd-runner])])
 AC_SUBST(KMOD_CFLAGS)

--- a/daemon/Makefile.am
+++ b/daemon/Makefile.am
@@ -3,12 +3,14 @@ sbin_PROGRAMS = nbd-runner
 nbd_runner_SOURCES = nbd-runner.c nbd-svc-routines.c gluster.c
 
 nbd_runner_CFLAGS = $(GFAPI_CFLAGS) $(EVENT_CFLAGS) $(GLIB2_CFLAGS) 	\
-                    $(TIRPC_CFLAGS) -DDATADIR=\"$(localstatedir)\"      \
+                    $(TIRPC_CFLAGS) $(JSONC_CFLAGS)						\
+					-DDATADIR=\"$(localstatedir)\"      				\
                     -I$(top_builddir)/ -I$(top_srcdir)/utils/           \
                     -I$(top_srcdir)/rpc
 
 nbd_runner_LDADD = $(PTHREAD) $(GFAPI_LIBS) $(EVENT_LIBS) $(GLIB2_LIBS) \
-                   $(TIRPC_LIBS) $(top_builddir)/rpc/libnbdrpcxdr.la    \
+                   $(TIRPC_LIBS) $(JSONC_LIBS)							\
+				   $(top_builddir)/rpc/libnbdrpcxdr.la    				\
                    $(top_builddir)/utils/libutils.la 
 
 DISTCLEANFILES = Makefile.in

--- a/daemon/gluster.c
+++ b/daemon/gluster.c
@@ -122,17 +122,21 @@ static bool glfs_cfg_parse(struct nbd_device *dev, const char *cfg,
     char *sep;
     char *ptr;
 
-    if (!cfg || !dev || !rep) {
-        rep->exit = -EINVAL;
-        snprintf(rep->out, NBD_EXIT_MAX, "The cfg param is NULL, will do nothing!");
+    if (!cfg || !dev) {
+        if (rep) {
+            rep->exit = -EINVAL;
+            snprintf(rep->out, NBD_EXIT_MAX, "The cfg param is NULL, will do nothing!");
+        }
         nbd_err("The cfg param is NULL, will do nothing!\n");
         return false;
     }
 
     info = calloc(1, sizeof(struct glfs_info));
     if (!info) {
-        rep->exit = -ENOMEM;
-        snprintf(rep->out, NBD_EXIT_MAX, "No memory for info!");
+        if (rep) {
+            rep->exit = -ENOMEM;
+            snprintf(rep->out, NBD_EXIT_MAX, "No memory for info!");
+        }
         nbd_err("No memory for info\n");
         goto err;
     }
@@ -140,8 +144,10 @@ static bool glfs_cfg_parse(struct nbd_device *dev, const char *cfg,
     /* skip the "key=" */
     tmp = strdup(cfg + 4);
     if (!tmp) {
-        rep->exit = -ENOMEM;
-        snprintf(rep->out, NBD_EXIT_MAX, "No memory for tmp!");
+        if (rep) {
+            rep->exit = -ENOMEM;
+            snprintf(rep->out, NBD_EXIT_MAX, "No memory for tmp!");
+        }
         nbd_err("No memory for tmp\n");
         goto err;
     }
@@ -166,8 +172,10 @@ static bool glfs_cfg_parse(struct nbd_device *dev, const char *cfg,
             /* volname@host:/path */
             sep = strchr(ptr, '@');
             if (!sep) {
-                rep->exit = -EINVAL;
-                snprintf(rep->out, NBD_EXIT_MAX, "Invalid volinfo key/pair: %s!", ptr);
+                if (rep) {
+                    rep->exit = -EINVAL;
+                    snprintf(rep->out, NBD_EXIT_MAX, "Invalid volinfo key/pair: %s!", ptr);
+                }
                 nbd_err("Invalid volinfo value: %s!\n", ptr);
                 goto err;
             }
@@ -179,8 +187,10 @@ static bool glfs_cfg_parse(struct nbd_device *dev, const char *cfg,
             ptr = sep + 1;
             sep = strchr(ptr, ':');
             if (!sep) {
-                rep->exit = -EINVAL;
-                snprintf(rep->out, NBD_EXIT_MAX, "Invalid volinfo host value: %s!", ptr);
+                if (rep) {
+                    rep->exit = -EINVAL;
+                    snprintf(rep->out, NBD_EXIT_MAX, "Invalid volinfo host value: %s!", ptr);
+                }
                 nbd_err("Invalid volinfo host value: %s!\n", ptr);
                 goto err;
             }
@@ -191,8 +201,10 @@ static bool glfs_cfg_parse(struct nbd_device *dev, const char *cfg,
 
             ptr = sep + 1;
             if (*ptr != '/') {
-                rep->exit = -EINVAL;
-                snprintf(rep->out, NBD_EXIT_MAX, "Invalid volinfo path value: %s!", ptr);
+                if (rep) {
+                    rep->exit = -EINVAL;
+                    snprintf(rep->out, NBD_EXIT_MAX, "Invalid volinfo path value: %s!", ptr);
+                }
                 nbd_err("Invalid path path value: %s!\n", ptr);
                 goto err;
             }

--- a/daemon/nbd-common.h
+++ b/daemon/nbd-common.h
@@ -22,6 +22,13 @@
 #include "rpc_nbd.h"
 #include "utils.h"
 
+typedef enum {
+    NBD_DEV_CONN_ST_CREATED,
+    NBD_DEV_CONN_ST_MAPPED,
+    NBD_DEV_CONN_ST_UNMAPPED,
+    NBD_DEV_CONN_ST_DEAD,
+} dev_status_t;
+
 struct nbd_device {
     handler_t type;
     struct nbd_handler *handler;
@@ -32,6 +39,8 @@ struct nbd_device {
     bool prealloc;
     ssize_t size;
     ssize_t blksize;
+
+    dev_status_t status;
 
     char nbd[NBD_DLEN_MAX]; /* e.g. "/dev/nbd14" */
     char time[NBD_TLEN_MAX]; /* e.g. "2019-02-12 12:00:37" */

--- a/daemon/nbd-runner.c
+++ b/daemon/nbd-runner.c
@@ -239,7 +239,6 @@ int main (int argc, char **argv)
     int ind;
 
     nbd_service_init();
-    handler_init();
 
     ret = nbd_log_init();
     if (ret < 0) {

--- a/utils/utils.h
+++ b/utils/utils.h
@@ -45,7 +45,10 @@
 #define NBD_RPC_SVC_PORT     24110
 #define NBD_MAP_SVC_PORT     24111
 
-#define  NBD_DEFAULT_SECTOR_SIZE  512
+#define NBD_DEFAULT_SECTOR_SIZE  512
+
+#define NBD_SAVE_CONFIG_DIR "/etc/nbd-runner"
+#define NBD_SAVE_CONFIG_FILE NBD_SAVE_CONFIG_DIR"/saveconfig.json"
 
 #define NBD_HOST_MAX  255
 #define NBD_CFGS_MAX  1024


### PR DESCRIPTION
When the nbd-runner restart, all the created/mapped backstore info
will be lost, save the info into the /etc/nbd-runner/saveconfig.json
then restore from it when starting.

The json file will be like:

{
  "dht@192.168.195.164:\/file57":{
    "type":0,
    "nbd":"\/dev\/nbd105",
    "maptime":"2019-03-11 18:48:25",
    "size":125829120,
    "blksize":4096,
    "readonly":false,
    "prealloc":false
  },
  "dht@192.168.195.164:\/file314":{
    "type":0,
    "nbd":"\/dev\/nbd106",
    "maptime":"2019-03-11 19:00:22",
    "size":1073741824,
    "blksize":4096,
    "readonly":false,
    "prealloc":false
  },
  "dht@192.168.195.164:\/file310":{
    "type":0,
    "nbd":"\/dev\/nbd107",
    "maptime":"2019-03-11 19:00:30",
    "size":1073741824,
    "blksize":4096,
    "readonly":false,
    "prealloc":false
  },
  "dht@192.168.195.164:\/file304":{
    "type":0,
    "nbd":"\/dev\/nbd108",
    "maptime":"2019-03-11 19:00:39",
    "size":1073741824,
    "blksize":4096,
    "readonly":false,
    "prealloc":false
  }

This is prepare for adding the remap command support.

Signed-off-by: Xiubo Li <xiubli@redhat.com>