### PR TITLE
travis: Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+sudo: required
+
+service:
+- docker
+
+script:
+- docker build -f ./Dockerfile.buildtest .

--- a/Dockerfile.buildtest
+++ b/Dockerfile.buildtest
@@ -1,0 +1,29 @@
+# Dockerfile for testing the build of gluster-block
+
+FROM fedora:29
+
+ENV BUILDDIR=/build
+RUN mkdir -p $BUILDDIR
+WORKDIR $BUILDDIR
+
+COPY . $BUILDDIR
+
+# prepare the system
+RUN true \
+ && dnf -y install \
+           git autoconf automake gcc libtool make file \
+           libevent-devel glib2-devel libnl3-devel     \
+           glusterfs-api-devel kmod-devel json-c-devel \
+           libtirpc-devel rpcgen                       \
+ && true
+
+# build
+RUN true \
+ && ./autogen.sh \
+ && ./configure --with-gfapi6=no \
+ && make \
+ && make check \
+ && make install \
+ && make clean \
+ && true
+

--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ nbd-runner is licensed to you under your choice of the GNU Lesser General Public
 <pre>
 # git clone https://github.com/gluster/nbd-runner.git
 # cd nbd-runner/
-# dnf install autoconf automake libtool glusterfs-api-devel kmod-devel libnl3-devel libevent-devel glib2-devel libtirpc-devel
+# dnf install autoconf automake libtool glusterfs-api-devel kmod-devel libnl3-devel libevent-devel glib2-devel json-c-devel
+# dnf install libtirpc-devel rpcgen # only in Fedora or some other Distributions that the glibc version >= 2.26
 # ./autogen.sh
-# ./configure # '--with-tirpc=no' means try to use legacy glibc, otherwise use libtirpc by default
+# ./configure # '--with-tirpc=no' means try to use legacy glibc, otherwise use libtirpc by default, '--with-gfapi6' means use GFAPI version >= 6.0
 # make -j
 # make install
 #

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AC_SUBST(LIBNL3_CFLAGS)
 AC_SUBST(LIBNL3_LIBS)
 
 AC_ARG_WITH([tirpc],
-    [AS_HELP_STRING([--with-tirpc], [do use tirpc])],
+    [AS_HELP_STRING([--with-tirpc], [do use tirpc, default yes])],
     [with_tirpc=$withval],
     [with_tirpc=missing])
 
@@ -80,11 +80,24 @@ else
 fi
 
 # Checks for libraries.
-# glusterfs-api versions have a prefix of "7."
-PKG_CHECK_MODULES([GFAPI], [glusterfs-api >= 7.4.1],,
-                  [AC_MSG_ERROR([gfapi library >= 4.1 is required to build nbd-runner])])
-AC_SUBST(GFAPI_CFLAGS)
-AC_SUBST(GFAPI_LIBS)
+AC_ARG_WITH([gfapi6],
+    [AS_HELP_STRING([--with-gfapi6], [do use new glfs APIs, default yes])],
+    [with_gfapi6=$withval],
+    [with_gfapi6=missing])
+
+if test "x$with_gfapi6" == "xyes" || test "x$with_gfapi6" == "xmissing"; then
+    # glusterfs-api versions have a prefix of "7."
+    PKG_CHECK_MODULES([GFAPI], [glusterfs-api >= 7.6],
+        [with_gfapi6="yes" AC_DEFINE(GFAPI_VER6, 1, [Define to 1 if we have gfapi library >= 6.0 support])],
+        [with_gfapi6="no" AC_DEFINE(GFAPI_VER6, 0) AC_MSG_ERROR([gfapi library >= 6.0 is required to build nbd-runner])])
+    AC_SUBST(GFAPI_CFLAGS)
+    AC_SUBST(GFAPI_LIBS)
+else
+    PKG_CHECK_MODULES([GFAPI], [glusterfs-api >= 7.4.1],,
+                      [AC_MSG_ERROR([gfapi library >= 4.1 is required to build nbd-runner])])
+    AC_SUBST(GFAPI_CFLAGS)
+    AC_SUBST(GFAPI_LIBS)
+fi
 
 AC_CHECK_LIB([pthread], [pthread_mutex_init],[PTHREAD="-lpthread"],
              AC_MSG_ERROR([Posix threads library is required to build nbd-runner]))
@@ -162,6 +175,7 @@ cat <<EOF
   $PACKAGE_NAME version $PACKAGE_VERSION
   Prefix.........: $prefix
   Use TIRPC......: $with_tirpc
+  Use GFAPI6.....: $with_gfapi6
   C Compiler.....: $CC $CFLAGS $CPPFLAGS
   Linker.........: $LD $LDFLAGS $LIBS
 ---------------------------------------------

--- a/daemon/gluster.c
+++ b/daemon/gluster.c
@@ -275,7 +275,11 @@ static bool glfs_create(struct nbd_device *dev, nbd_response *rep)
         goto err;
     }
 
+#if GFAPI_VER6
     if (glfs_ftruncate(fd, dev->size, NULL, NULL) < 0) {
+#else
+    if (glfs_ftruncate(fd, dev->size) < 0) {
+#endif
         rep->exit = -errno;
         snprintf(rep->out, NBD_EXIT_MAX, "Failed to truncate file %s on volume %s!",
                  info->path, info->volume);
@@ -528,10 +532,15 @@ err:
     return ret;
 }
 
+#if GFAPI_VER6
 static void glfs_async_cbk(glfs_fd_t *gfd, ssize_t ret,
                            struct glfs_stat *prestat,
                            struct glfs_stat *poststat,
                            void *data)
+#else
+static void glfs_async_cbk(glfs_fd_t *gfd, ssize_t ret,
+                           void *data)
+#endif
 {
     struct nbd_handler_request *req = data;
 


### PR DESCRIPTION
This travis.yml and Dockerfile code are initially copied from:
gluster/gluster-block#142.

Thanks Michael Adam <obnox@redhat.com>.

And add more changes to make it works for us.

Signed-off-by: Xiubo Li <xiubli@redhat.com>