### PR TITLE
gluster: add volume cache support

### DIFF
--- a/daemon/nbd-svc-routines.c
+++ b/daemon/nbd-svc-routines.c
@@ -944,12 +944,12 @@ int rpc_nbd_1_freeresult(SVCXPRT *transp, xdrproc_t xdr_result, caddr_t result)
     return 1;
 }
 
-void free_key(gpointer key)
+static void free_key(gpointer key)
 {
     free(key);
 }
 
-void free_value(gpointer value)
+static void free_value(gpointer value)
 {
     struct nbd_device *dev = value;
 


### PR DESCRIPTION
The volume's new/init is very slow and will take about 3 second
everytime. Here add one volume cache to speed it up.

It's better to switch to LRU method instead of the unlimit hash
array and will do it in future.

Signed-off-by: Xiubo Li <xiubli@redhat.com>