### PR TITLE
nbd-runner: fix g_hash assert table !=NULL warning

### DIFF
--- a/daemon/nbd-svc-routines.c
+++ b/daemon/nbd-svc-routines.c
@@ -1050,9 +1050,14 @@ err:
 
 void nbd_service_fini(void)
 {
-    g_hash_table_destroy(nbd_handler_hash);
-    g_hash_table_destroy(nbd_devices_hash);
-    g_hash_table_destroy(nbd_nbds_hash);
+    if (nbd_handler_hash)
+        g_hash_table_destroy(nbd_handler_hash);
+
+    if (nbd_devices_hash)
+        g_hash_table_destroy(nbd_devices_hash);
+
+    if (nbd_nbds_hash)
+        g_hash_table_destroy(nbd_nbds_hash);
 }
 
 int nbd_register_handler(struct nbd_handler *handler)


### PR DESCRIPTION
(process:13798): GLib-CRITICAL **: 19:01:55.957: g_hash_table_destroy:
assertion 'hash_table != NULL' failed

(process:13798): GLib-CRITICAL **: 19:01:55.957: g_hash_table_destroy:
assertion 'hash_table != NULL' failed

(process:13798): GLib-CRITICAL **: 19:01:55.957: g_hash_table_destroy:
assertion 'hash_table != NULL' failed

Signed-off-by: Xiubo Li <xiubli@redhat.com>